### PR TITLE
Redirecting user to dashboard upon successful registration.

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -48,7 +48,13 @@ def register(request):
                 new_user.profile.address = form.data['address']
                 new_user.profile.city = form.data['city']
                 new_user.profile.country = form.data['country']
+                new_user.is_active = True
                 new_user.save()
+                login(request, new_user)
+                messages.success(
+                    request,
+                    'Registration was successful. Welcome to Auto-shop.',
+                )
                 return redirect('/')
 
         print 'Profile for user "%s" failed to save due to validation errors: %s' % (

--- a/external_auth/views.py
+++ b/external_auth/views.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.contrib.auth import authenticate, login
 from django.contrib.auth.models import User
 from django.contrib import messages
 from external_auth.forms import PakwheelsLoginForm
@@ -48,7 +49,9 @@ def pakwheels_registration(request):
             user.profile.date_of_birth = pakwheels_profile.birthday
             user.profile.city = pakwheels_profile.city
             user.profile.country = pakwheels_profile.country
+            user.is_active = True
             user.save()
+            login(request, user)
             messages.success(
                 request,
                 'Pakwheels login successful.'
@@ -56,6 +59,7 @@ def pakwheels_registration(request):
                 ' You can change your password.',
             )
             return render(request, 'home.html')
+
     else:
         messages.error(request, 'The Pakwheels credentials are incorrect. Please try again.')
         return render(request, 'pakwheels_register.html', context={'form': pakwheels_login_form})


### PR DESCRIPTION
The users were previously being directed to ```Autoshop``` main page and were required to login after registration to enter site. This extra step has been reduced and at successful registration, the user is also logged in and ready to use site. User with ```Pakwheels``` profile will also be directed to dashboard page upon successful registration.